### PR TITLE
Move core of CI to GitHub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Check that the package and website can build correctly
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test-building:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - run: npm ci
+
+      - name: Build package
+        run: npm run lib
+
+      - name: Build website
+        run: npm run build
+
+      - name: Build docs
+        run: |
+          cd docs
+          npm ci
+          npm run build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Check that the package and website can build correctly
+name: Check that everything builds correctly
 
 on:
   push:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,31 @@
+name: Run static checks
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  run-static-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - run: npm ci
+
+      - name: Check formatting with prettier
+        run: npm run prettier:check
+
+      - name: Check for issues with eslint
+        run: npm run lint
+
+      - name: Check for type errors with typescript
+        run: npm run tsc
+
+      - name: Run unit tests
+        run: npm run test

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -2,14 +2,28 @@ name: Submit to coveralls
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
-  test:
+  submit-coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
       - run: npm ci
-      - run: npm run coverage
-      - uses: coverallsapp/github-action@v2
+
+      - name: Test
+        run: npm run coverage
+
+      - name: Submit
+        uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: Publish NPM Package
 
 on:
+  push:
+    branches:
+      - publish
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,5 +24,5 @@ jobs:
 
       - name: Publish package
         env:
-          NODE_AUTH_TOKEN: "${{ secrets.NPM_PUBLISH_TOKEN }}"
+          NODE_AUTH_TOKEN: '${{ secrets.NPM_PUBLISH_TOKEN }}'
         run: npm publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish NPM Package
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+      - run: npm ci
+
+      - name: Build package
+        run: npm run lib
+
+      - name: Publish package
+        env:
+          NODE_AUTH_TOKEN: "${{ secrets.NPM_PUBLISH_TOKEN }}"
+        run: npm publish

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ set programming.
 
 - Dusa lives online at [dusa.rocks](https://dusa.rocks/).
 - Documentation lives at [dusa.rocks/docs](https://dusa.rocks/docs/)
-- [Source code at sourcehut](https://git.sr.ht/~robsimmons/dusa)
-- [Issue tracker at sourcehut](https://todo.sr.ht/~robsimmons/Dusa)
+- [Source code on GitHub](https://github.com/robsimmons/dusa)
+- [Issue tracker at GitHub](https://github.com/robsimmons/dusa/issues)
 
 Dusa was initially developed by Rob Simmons and Chris Martens while Rob attended
 [Recurse Center](https://www.recurse.com/) in Fall 2023. Recurse center is a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dusa",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dusa",
-      "version": "0.0.13",
+      "version": "0.0.14",
       "license": "GPL-3.0-only",
       "devDependencies": {
         "@bufbuild/protobuf": "^1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dusa",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "type": "module",
   "main": "lib/client.js",
   "types": "lib/client.d.ts",


### PR DESCRIPTION
I liked putting early development on SourceHut, but for the moment it makes collaboration with folks here more difficult. Addresses #28.