### PR TITLE
[generating graphs example] rename some variables for clarity

### DIFF
--- a/src/web/examples.ts
+++ b/src/web/examples.ts
@@ -161,7 +161,7 @@ edge X Y is { extant, absent } :- vertex X, vertex Y, X != Y.
 edge X Y is Z :- edge Y X is Z.
 
 reachable N N :- vertex N.
-reachable Start Y :- reachable Start X, edge X Y is extant.
+reachable X Z :- reachable X Y, edge Y Z is extant.
 
 #demand reachable 0 1.
 #demand reachable 5 6.


### PR DESCRIPTION
`Start` being a full word confused me. In the rest of the example, variables are all a single letter, and full words are reserved for uninterpreted functions. Also, this is an undirected graph, so there's no need to distinguish one end of a path as the "start".