### PR TITLE
Additional coverage & error messages

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -20,10 +20,9 @@ function runForDusaError(program: string) {
   } catch (e) {
     if (e instanceof DusaError) {
       return e.issues.map(({ msg }) => msg);
-    } else {
-      return null;
     }
   }
+  return null;
 }
 
 let dusa: Dusa;

--- a/src/language/dusa-parser.ts
+++ b/src/language/dusa-parser.ts
@@ -89,13 +89,15 @@ function mkStream<T>(xs: T[]): ImperativeStream<T> {
 
 function force(t: ImperativeStream<Token>, type: string): Token {
   const tok = t.next();
-  if (tok === null)
+  if (tok === null) {
     throw new DusaSyntaxError(`Expected to find '${type}', but instead reached the end of input.`);
-  if (tok.type !== type)
+  }
+  if (tok.type !== type) {
     throw new DusaSyntaxError(
       `Expected to find '${type}', but instead found '${tok.type}'.`,
       tok.loc,
     );
+  }
   return tok;
 }
 

--- a/src/language/dusa-tokenizer.ts
+++ b/src/language/dusa-tokenizer.ts
@@ -48,11 +48,11 @@ export type Token =
 
 export type ParserState = StateRoot;
 
-const META_ID_TOKEN = /^[A-Za-z_][A-Za-z0-9_]*/;
+const META_ID_TOKEN = /^[A-Za-z_][A-Za-z0-9_']*/;
 const META_NUM_TOKEN = /^[+-]?[0-9][A-Za-z0-9_]*/;
 const CONST_TOKEN = /^[a-z][a-zA-Z0-9_]*$/;
-const WILDCARD_TOKEN = /^_[a-zA-Z0-9_]*$/;
-const VAR_TOKEN = /^[A-Z][a-zA-Z0-9_]*$/;
+const WILDCARD_TOKEN = /^_[a-zA-Z0-9_']*$/;
+const VAR_TOKEN = /^[A-Z][a-zA-Z0-9_']*$/;
 const INT_TOKEN = /^-?(0|[1-9][0-9]*)$/;
 const TRIV_TOKEN = /^\(\)/;
 
@@ -125,116 +125,111 @@ export const dusaTokenizer: StreamParser<ParserState, Token> = {
           };
         }
 
-        if (stream.eat('\\')) {
-          if (
-            (tok = stream.eat(/^([0bfnrtv'"\\]|x[0-9a-fA-F][0-9a-fA-F]|u\{[0-9a-fA-F]{1,6}\})/))
-          ) {
-            switch (tok[0]) {
-              case '0':
-                tok = '\0';
+        stream.eat('\\'); // Expected to always return non-null
+        if ((tok = stream.eat(/^([0bfnrtv'"\\]|x[0-9a-fA-F][0-9a-fA-F]|u\{[0-9a-fA-F]+\})/))) {
+          switch (tok[0]) {
+            case '0':
+              tok = '\0';
+              break;
+            case 'b':
+              tok = '\b';
+              break;
+            case 'f':
+              tok = '\f';
+              break;
+            case 'n':
+              tok = '\n';
+              break;
+            case 'r':
+              tok = '\r';
+              break;
+            case 't':
+              tok = '\t';
+              break;
+            case 'v':
+              tok = '\v';
+              break;
+            case "'":
+              tok = "'";
+              break;
+            case '"':
+              tok = '"';
+              break;
+            case '\\':
+              tok = '\\';
+              break;
+            case 'x':
+              tok = String.fromCharCode(parseInt(tok.slice(1), 16));
+              break;
+            default: {
+              // case 'u'
+              const charCode = parseInt(tok.slice(2, tok.length - 1), 16);
+              if (0xd800 <= charCode && charCode < 0xe000) {
+                return {
+                  state,
+                  issues: [
+                    {
+                      type: 'Issue',
+                      msg: `Cannot encode lone surrogate \\${tok}`,
+                      severity: 'error',
+                      loc: stream.matchedLocation(),
+                    },
+                  ],
+                };
+              }
+              if (charCode > 0x10ffff) {
+                return {
+                  state,
+                  issues: [
+                    {
+                      type: 'Issue',
+                      msg: `Bad Unicode code point \\${tok}`,
+                      severity: 'error',
+                      loc: stream.matchedLocation(),
+                    },
+                  ],
+                };
+              } else {
+                tok = String.fromCodePoint(charCode);
                 break;
-              case 'b':
-                tok = '\b';
-                break;
-              case 'f':
-                tok = '\f';
-                break;
-              case 'n':
-                tok = '\n';
-                break;
-              case 'r':
-                tok = '\r';
-                break;
-              case 't':
-                tok = '\t';
-                break;
-              case 'v':
-                tok = '\v';
-                break;
-              case "'":
-                tok = "'";
-                break;
-              case '"':
-                tok = '"';
-                break;
-              case '\\':
-                tok = '\\';
-                break;
-              case 'x':
-                tok = String.fromCharCode(parseInt(tok.slice(1), 16));
-                break;
-              default: {
-                // case 'u'
-                const charCode = parseInt(tok.slice(2, tok.length - 1), 16);
-                if (0xd800 <= charCode && charCode < 0xe000) {
-                  return {
-                    state,
-                    issues: [
-                      {
-                        type: 'Issue',
-                        msg: `Cannot encode lone surrogate ${tok}`,
-                        severity: 'error',
-                        loc: stream.matchedLocation(),
-                      },
-                    ],
-                  };
-                }
-                if (charCode > 0x10ffff) {
-                  return {
-                    state,
-                    issues: [
-                      {
-                        type: 'Issue',
-                        msg: `Bad Unicode code point ${tok}`,
-                        severity: 'error',
-                        loc: stream.matchedLocation(),
-                      },
-                    ],
-                  };
-                } else {
-                  tok = String.fromCodePoint(charCode);
-                  break;
-                }
               }
             }
-            return {
-              state: {
-                ...state,
-                collected: state.collected + tok,
-                end: stream.matchedLocation().end,
-              },
-              tag: 'escape',
-            };
-          }
-          if ((tok = stream.eat(/^./))) {
-            return {
-              state,
-              tag: 'invalid',
-              issues: [
-                {
-                  type: 'Issue',
-                  msg: `Invalid escape sequence \\${tok}`,
-                  severity: 'error',
-                  loc: stream.matchedLocation(),
-                },
-              ],
-            };
           }
           return {
-            state: { type: 'Normal' },
+            state: {
+              ...state,
+              collected: state.collected + tok,
+              end: stream.matchedLocation().end,
+            },
+            tag: 'escape',
+          };
+        }
+        if ((tok = stream.eat(/^./))) {
+          return {
+            state,
             tag: 'invalid',
             issues: [
               {
                 type: 'Issue',
-                msg: 'Backslash not supported at end of line',
+                msg: `Invalid escape sequence \\${tok}`,
                 severity: 'error',
                 loc: stream.matchedLocation(),
               },
             ],
           };
         }
-
-        throw new Error('Expected-to-be-unimpossible state in string parsing reached');
+        return {
+          state: { type: 'Normal' },
+          tag: 'invalid',
+          issues: [
+            {
+              type: 'Issue',
+              msg: 'Backslash not supported at end of line',
+              severity: 'error',
+              loc: stream.matchedLocation(),
+            },
+          ],
+        };
 
       case 'Normal':
         if ((tok = stream.eat('#'))) {
@@ -286,10 +281,6 @@ export const dusaTokenizer: StreamParser<ParserState, Token> = {
               tree: { type: p, loc: stream.matchedLocation() },
             };
           }
-        }
-
-        if (stream.eat(/^\s+/)) {
-          return { state };
         }
 
         if ((tok = stream.eat(META_ID_TOKEN) ?? stream.eat(META_NUM_TOKEN))) {


### PR DESCRIPTION
Simplifies the tokenizer in one case and adds a backslash to bad unicode error messages, otherwise just coverage.