### PR TITLE
Bugfix on facts iterator, and tests for the same

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dusa",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dusa",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "GPL-3.0-only",
       "bin": {
         "dusa": "dusa"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dusa",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "main": "lib/client.js",
   "unpkg": "./dusa.umd.js",

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -177,6 +177,20 @@ test('Builtin STRING_CONCAT', () => {
   ).toStrictEqual(['']);
 });
 
+test('Facts', () => {
+  expect(new Dusa('a. b 1. c 2 3. d e is "f". g (h i) is ().').solution?.facts()).toStrictEqual([
+    { name: 'a', args: [] },
+    { name: 'b', args: [1] },
+    { name: 'c', args: [2, 3] },
+    { name: 'd', args: [{ name: 'e' }], value: 'f' },
+    { name: 'g', args: [{ name: 'h', args: [{ name: 'i' }] }], value: null },
+  ]);
+
+  expect(new Dusa('a 1 () "3" four 5 is ().').solution?.factsBig()).toStrictEqual([
+    { name: 'a', args: [1n, null, '3', { name: 'four' }, 5n], value: null },
+  ]);
+});
+
 test('Builtin STRING_CONCAT, full reverse', () => {
   expect(
     solutions(new Dusa('#builtin STRING_CONCAT concat\nres X Y :- concat X Y is "abc".')),

--- a/src/client.ts
+++ b/src/client.ts
@@ -295,12 +295,14 @@ class DusaSolutionImpl implements DusaSolution {
     const arity = this.prog.arities[name];
     if (!arity) return;
     const depth = (arity.value ? arity.args + 1 : arity.args) - args.length;
-    yield* this.solution.visit(
-      name,
-      args.map((arg) => termToData(this.prog.data, arg)),
-      args.length,
-      depth,
-    );
+    yield* this.solution
+      .visit(
+        name,
+        args.map((arg) => termToData(this.prog.data, arg)),
+        args.length,
+        depth,
+      )
+      .map((tms) => tms.slice(0));
   }
 
   *lookup(name: string, ...args: InputTerm[]) {


### PR DESCRIPTION
The facts and factsBig iterator was broken because of the changes in 0.1.2 - always missing the last argument. Fixed here!