### PR TITLE
builtin-indentifier and builtin both used in syntax.md

### DIFF
--- a/docs/src/content/docs/docs/language/syntax.md
+++ b/docs/src/content/docs/docs/language/syntax.md
@@ -39,11 +39,11 @@ treated like whitespace.
     <arguments>       ::= <atomic-term> | <atomic-term> <arguments>
     <atomic-term>     ::= <wildcard> | <variable>
                        |  <string-literal> | <int-literal>
-                       |  <identifier> | <builtin-identifier>
+                       |  <identifier> | <builtin>
                        |  "(" <term> ")"
     <term>            ::= <atomic-term>
                        |  <identifier> <arguments>
-                       |  <builtin-identifier> <arguments>
+                       |  <builtin> <arguments>
     <builtin>         ::= "BOOLEAN_TRUE" | "BOOLEAN_FALSE"
                        |  "NAT_ZERO" | "NAT_SUCC"
                        |  "INT_PLUS" | "INT_MINUS" | "INT_TIMES"

--- a/docs/src/content/docs/docs/language/syntax.md
+++ b/docs/src/content/docs/docs/language/syntax.md
@@ -39,7 +39,7 @@ treated like whitespace.
     <arguments>       ::= <atomic-term> | <atomic-term> <arguments>
     <atomic-term>     ::= <wildcard> | <variable>
                        |  <string-literal> | <int-literal>
-                       |  <identifier> | <builtin>
+                       |  <identifier>
                        |  "(" <term> ")"
     <term>            ::= <atomic-term>
                        |  <identifier> <arguments>

--- a/docs/src/content/docs/docs/language/syntax.md
+++ b/docs/src/content/docs/docs/language/syntax.md
@@ -43,7 +43,6 @@ treated like whitespace.
                        |  "(" <term> ")"
     <term>            ::= <atomic-term>
                        |  <identifier> <arguments>
-                       |  <builtin> <arguments>
     <builtin>         ::= "BOOLEAN_TRUE" | "BOOLEAN_FALSE"
                        |  "NAT_ZERO" | "NAT_SUCC"
                        |  "INT_PLUS" | "INT_MINUS" | "INT_TIMES"


### PR DESCRIPTION
When reading the docs, I was confused what \<builtin-identifier> was supposed to represent.
I assume it means the same thing as \<builtin>, so I have set them to the the same name.

<builtin> was chosen as the standard over \<builtin-indentifier> because it didn't mess with the whitespace